### PR TITLE
Updates descriptions to match time_in_minutes

### DIFF
--- a/pom
+++ b/pom
@@ -8,7 +8,7 @@
 #     pom message [-l [logfile]]
 #
 # DESCRIPTION
-#     The pom utility counts down for 20 minutes as you work on a task. It will
+#     The pom utility counts down for 25 minutes as you work on a task. It will
 #     give an audible alert at 5 and 0 minutes if `say` is in the path and
 #     executable.
 #
@@ -77,7 +77,7 @@ function print_help {
       pom message [-l [logfile]]
 
   DESCRIPTION
-      The pom utility counts down for 20 minutes as you work on a task. It will
+      The pom utility counts down for 25 minutes as you work on a task. It will
       give an audible alert at 5 and 0 minutes if `say` is in the path and
       executable.
 


### PR DESCRIPTION
The time_in_minutes is set to 25, but the description lists the count
down time as 20 minutes (both in the comment header and the help text).

A previous pull request from @twe4ked fixes the README, so that was
left untouched.
