### PR TITLE
Improved support for non MacOS platforms

### DIFF
--- a/pom
+++ b/pom
@@ -56,8 +56,9 @@ function finish {
 function safe_say {
   for cmd in espeak say
   do
-    which $cmd >/dev/null && $cmd "$1" 2>/dev/null && break
+    which $cmd >/dev/null && $cmd "$1" 2>/dev/null && return
   done
+  return 1
 }
 
 # Try to ring the terminal bell.

--- a/pom
+++ b/pom
@@ -47,7 +47,7 @@ function finish {
     echo $msg >> $logfile
   fi
 
-  break_msg="Pomadoro complete. Take a 5 minute break."
+  break_msg="Pomodoro complete. Take a 5 minute break."
   echo $break_msg
   safe_say "$break_msg" || ring_bell
 }

--- a/pom
+++ b/pom
@@ -32,7 +32,7 @@ function print_status {
 
   if [ $minutes_remaining = 5 ]
   then
-    safe_say "$minutes_remaining minutes remaining in your pomadoro"
+    safe_say "$minutes_remaining minutes remaining in your pomadoro" &
   fi
 }
 

--- a/pom
+++ b/pom
@@ -54,7 +54,10 @@ function finish {
 
 # Audibly say something, if possible.
 function safe_say {
-  which -s say && say $1
+  for cmd in espeak say
+  do
+    which $cmd >/dev/null && $cmd "$1" 2>/dev/null && break
+  done
 }
 
 # Try to ring the terminal bell.

--- a/pom
+++ b/pom
@@ -59,7 +59,7 @@ function safe_say {
 
 # Try to ring the terminal bell.
 function ring_bell {
-  which -s tput && tput bel
+  which tput >/dev/null && tput bel
 }
 
 # Print short version of help.


### PR DESCRIPTION
This patch adds support for espeak, fixes a misspelling, and is now compatible with GNU which (it doesn't support BSD -s flag). It also ensures the 5-minute warning doesn't distort the timing of the pomodoro.
